### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@
 
 name: build
 on: [pull_request, push]
+permissions:
+  contents: read
 
 jobs:
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/adharshgamingyt/AdvancedCraft/security/code-scanning/1](https://github.com/adharshgamingyt/AdvancedCraft/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level (applies to all jobs) to explicitly define the least privileges required. Based on the workflow's steps:
- The `actions/checkout@v4` action requires `contents: read` to clone the repository.
- The `actions/upload-artifact@v4` action also requires `contents: read` to upload artifacts.

No other steps in the workflow require additional permissions. Therefore, we will set `permissions: contents: read` at the root of the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
